### PR TITLE
[WIP] Add Node FTL build template

### DIFF
--- a/ftl/README.md
+++ b/ftl/README.md
@@ -1,0 +1,33 @@
+# FTL
+
+This build template builds source into a container image using the "FTL" model
+for quickly and efficiently building container images from source.
+
+Currently the only supported source language in this repo is NodeJS. More
+languages will be supported in the future.
+
+## Parameters
+
+* **IMAGE**: The Docker image name to apply to the newly built image.
+  (_required_)
+**DIRECTORY:** The directory in the source repository where source
+  should be found. (_default:_ `/workspace`)
+
+## Usage
+
+```
+apiVersion: build.dev/v1alpha1
+kind: Build
+metadata:
+  name: node-ftl-build
+spec:
+  source:
+    git:
+      url: https://github.com/my-user/my-repo
+      branch: master
+  template:
+    name: node-ftl
+    arguments:
+    - name: IMAGE
+      value: us.gcr.io/my-project/my-app
+```

--- a/ftl/node-ftl.yaml
+++ b/ftl/node-ftl.yaml
@@ -1,0 +1,38 @@
+# Copyright 2018 Google, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: build.dev/v1alpha1
+kind: BuildTemplate
+metadata:
+  name: node-fn
+spec:
+  parameters:
+  - name: IMAGE
+    description: The name of the image to push.
+  - name: DIRECTORY
+    description: The directory containing the build context
+    default: /workspace
+
+  steps:
+  - name: node-ftl
+    image: gcr.io/gcp-runtimes/ftl_node_8_5_0_ubuntu_16_0_4_build:f1607c1721353971301dae01ac911ddcd3d39388
+    args:
+    - "--base=gcr.io/gae-runtimes/nodejs8_fn:8_10_0_nightly_20180322_RC00"
+    - "--directory=${DIRECTORY}"
+    - "--destination=/srv"
+    - "--cache-repository=${IMAGE}"
+    - "--entrypoint=\"node /worker/worker.js --max-old-space-size=100\""
+    - "--name=${IMAGE}:latest"
+    env:
+    - name: DOCKER_CONFIG
+      value: /root/.docker


### PR DESCRIPTION
Open Questions:

1.) What builder image should be used?

  * both templates in elafros/sample/templates use `gcr.io/gcp-runtimes/ftl_node_8_5_0_ubuntu_16_0_4_build:f1607c1721353971301dae01ac911ddcd3d39388`

Is there some more sane tag that can be used?

2.) What base image should be used by default?

  * [elafros/sample/templates/node-app.yaml](https://github.com/elafros/elafros/blob/master/sample/templates/node-app.yaml#L30) uses `gcr.io/gae-runtimes/nodejs8:nodejs8_20180417b_RC00`
  * [elafros/sample/templates/node-fn.yaml](https://github.com/elafros/elafros/blob/master/sample/templates/node-fn.yaml#L30) uses `gcr.io/gae-runtimes/nodejs8_fn:8_10_0_nightly_20180322_RC00`

Is there some more sane tag that can be used?

3.) Should `entrypoint` be a build template paramater?

  * [elafros/sample/templates/node-app.yaml](https://github.com/elafros/elafros/blob/master/sample/templates/node-app.yaml) does not have an entrypoint specified.
  * [elafros/sample/templates/node-fn.yaml](https://github.com/elafros/elafros/blob/master/sample/templates/node-fn.yaml#L34) specifies `--entrypoint=\"node /worker/worker.js --max-old-space-size=100\"`

4.) Are there any more options that are accepted by the FTL builder image?

5.) Can we take this opportunity to document FTL better? Otherwise, the FTL README.md is pretty scant. 🙁 

Fixes #5 