### PR TITLE
Update buildpack.yaml

### DIFF
--- a/buildpack/buildpack.yaml
+++ b/buildpack/buildpack.yaml
@@ -39,9 +39,6 @@ spec:
     image: packs/cf:export
     workingdir: /in
     args: ["${IMAGE}"]
-    env:
-    - name: PACK_REGISTRY_GCR
-      value: "true"
     volumeMounts:
     - name: droplet
       mountPath: /in


### PR DESCRIPTION
Removed unused env var `PACK_REGISTRY_GCR`

The export image no longer needs it