### PR TITLE
Change default for Dockerfile in kaniko template

### DIFF
--- a/kaniko/kaniko.yaml
+++ b/kaniko/kaniko.yaml
@@ -8,7 +8,7 @@ spec:
     description: The name of the image to push
   - name: DOCKERFILE
     description: Path to the Dockerfile to build.
-    default: ./Dockerfile
+    default: /workspace/Dockerfile
 
   steps:
   - name: build-and-push


### PR DESCRIPTION
- build fails without including `/workspace` in path