### PR TITLE
Add install instructions from public GitHub repo

### DIFF
--- a/bazel/README.md
+++ b/bazel/README.md
@@ -31,7 +31,7 @@ popular programming languages, like
 ## Create the template
 
 ```
-kubectl apply -f https://raw.githubusercontent.com/knative/build-templates/bazel/bazel.yaml
+kubectl apply -f https://raw.githubusercontent.com/knative/build-templates/master/bazel/bazel.yaml
 ```
 
 ## Parameters

--- a/buildpack/README.md
+++ b/buildpack/README.md
@@ -11,7 +11,7 @@ the resulting application image to a Docker registry under the provided name.
 ## Create the template
 
 ```
-kubectl apply -f https://raw.githubusercontent.com/knative/build-templates/buildpack/buildpack.yaml
+kubectl apply -f https://raw.githubusercontent.com/knative/build-templates/master/buildpack/buildpack.yaml
 ```
 
 ## Parameters

--- a/jib/README.md
+++ b/jib/README.md
@@ -35,7 +35,7 @@ for more information.
 To use the `jib-maven` template, first install the template:
 
 ```
-kubectl apply -f https://raw.githubusercontent.com/knative/build-templates/jib/jib-maven.yaml
+kubectl apply -f https://raw.githubusercontent.com/knative/build-templates/master/jib/jib-maven.yaml
 ```
 
 Then, define a build that instantiates the template:
@@ -71,7 +71,7 @@ Gradle](https://github.com/GoogleContainerTools/jib/tree/master/jib-gradle-plugi
 To use the `jib-gradle` template, first install the template:
 
 ```
-kubectl apply -f https://raw.githubusercontent.com/knative/build-templates/jib/jib-gradle.yaml
+kubectl apply -f https://raw.githubusercontent.com/knative/build-templates/master/jib/jib-gradle.yaml
 ```
 
 Then, define a build that instantiates the template:

--- a/kaniko/README.md
+++ b/kaniko/README.md
@@ -15,7 +15,7 @@ makes it a perfect tool to be part of a Knative build.
 ## Create the template
 
 ```
-kubectl apply -f https://raw.githubusercontent.com/knative/build-templates/kaniko/kaniko.yaml
+kubectl apply -f https://raw.githubusercontent.com/knative/build-templates/master/kaniko/kaniko.yaml
 ```
 
 ## Parameters


### PR DESCRIPTION
This change can't be merged until the repo is public, but when it is, update install instructions that reference the template configs from GitHub.

Longer-term we should probably have a real release process for some of these templates, but at least being able to install them with a single command is progress.

/hold