### PR TITLE
Mac support for gcr_helper

### DIFF
--- a/gcr_helper/helper.sh
+++ b/gcr_helper/helper.sh
@@ -155,8 +155,8 @@ metadata:
     build.knative.dev/docker-3: https://asia.gcr.io
 type: kubernetes.io/basic-auth
 data:
-  username: $(echo -n "_json_key" | base64 -w 0) # Should be X2pzb25fa2V5
-  password: $(base64 -w 0 image-push-key.json)
+  username: $(echo -n "_json_key" | openssl base64 -a -A) # Should be X2pzb25fa2V5
+  password: $(openssl base64 -a -A < image-push-key.json)
 EOF
 
 readonly EXIT=$?


### PR DESCRIPTION
The base64 command is using the `-w` flag to disable wrapping. On the Mac the equivalent flag is `-b`.  There is no common flag that will disable wrapping.

One option is to use `openssl base64 -a -A`. I'm not sure that's the right answer, but I'm opening a PR to start the discussion.

/assign @ImJasonH 