### PR TITLE
Use e2e-tests.sh helper from prow-tests image

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -23,19 +23,11 @@
 # Calling this script without arguments will create a new cluster in
 # project $PROJECT_ID, run the tests and delete the cluster.
 
-[ -f /workspace/library.sh ] && source /workspace/library.sh || eval "$(docker run --entrypoint sh gcr.io/knative-tests/test-infra/prow-tests -c 'cat library.sh')"
+# Load github.com/knative/test-infra/images/prow-tests/scripts/e2e-tests.sh
+[ -f /workspace/e2e-tests.sh ] \
+  && source /workspace/e2e-tests.sh \
+  || eval "$(docker run --entrypoint sh gcr.io/knative-tests/test-infra/prow-tests -c 'cat e2e-tests.sh')"
 [ -v KNATIVE_TEST_INFRA ] || exit 1
-
-# Test cluster parameters and location of test files
-readonly E2E_CLUSTER_NAME=bldtpl-e2e-cluster${BUILD_NUMBER}
-readonly E2E_NETWORK_NAME=bldtpl-e2e-net${BUILD_NUMBER}
-readonly E2E_CLUSTER_ZONE=us-central1-a
-readonly E2E_CLUSTER_NODES=2
-readonly E2E_CLUSTER_MACHINE=n1-standard-2
-readonly TEST_RESULT_FILE=/tmp/bldtpl-e2e-result
-
-# This script.
-readonly SCRIPT_CANONICAL_PATH="$(readlink -f ${BASH_SOURCE})"
 
 # Helper functions.
 
@@ -54,104 +46,18 @@ function run_buildpack_test() {
   # TODO(adrcunha): Add proper verification.
 }
 
-function exit_if_test_failed() {
-  [[ $? -eq 0 ]] && return 0
-  [[ -n $1 ]] && echo "ERROR: $1"
-  echo "***************************************"
-  echo "***           TEST FAILED           ***"
-  echo "***    Start of information dump    ***"
-  echo "***************************************"
-  echo ">>> All resources:"
-  kubectl get all --all-namespaces
-  echo "***************************************"
-  echo "***           TEST FAILED           ***"
-  echo "***     End of information dump     ***"
-  echo "***************************************"
-  exit 1
-}
-
 # Script entry point.
 
-cd ${REPO_ROOT_DIR}
-
-# Show help if bad arguments are passed.
-if [[ -n $1 && $1 != "--run-tests" ]]; then
-  echo "usage: $0 [--run-tests]"
-  exit 1
-fi
-
-# No argument provided, create the test cluster.
-
-if [[ -z $1 ]]; then
-  header "Creating test cluster"
-  # Smallest cluster required to run the end-to-end-tests
-  CLUSTER_CREATION_ARGS=(
-    --gke-create-args="--enable-autoscaling --min-nodes=1 --max-nodes=${E2E_CLUSTER_NODES} --scopes=cloud-platform"
-    --gke-shape={\"default\":{\"Nodes\":${E2E_CLUSTER_NODES}\,\"MachineType\":\"${E2E_CLUSTER_MACHINE}\"}}
-    --provider=gke
-    --deployment=gke
-    --gcp-node-image=cos
-    --cluster="${E2E_CLUSTER_NAME}"
-    --gcp-zone="${E2E_CLUSTER_ZONE}"
-    --gcp-network="${E2E_NETWORK_NAME}"
-    --gke-environment=prod
-  )
-  if (( ! IS_PROW )); then
-    CLUSTER_CREATION_ARGS+=(--gcp-project=${PROJECT_ID:?"PROJECT_ID must be set to the GCP project where the tests are run."})
-  fi
-  # SSH keys are not used, but kubetest checks for their existence.
-  # Touch them so if they don't exist, empty files are create to satisfy the check.
-  touch $HOME/.ssh/google_compute_engine.pub
-  touch $HOME/.ssh/google_compute_engine
-  # Assume test failed (see more details at the end of this script).
-  echo -n "1"> ${TEST_RESULT_FILE}
-  kubetest "${CLUSTER_CREATION_ARGS[@]}" \
-    --up \
-    --down \
-    --extract "gke-${GKE_VERSION}" \
-    --test-cmd "${SCRIPT_CANONICAL_PATH}" \
-    --test-cmd-args --run-tests
-  result="$(cat ${TEST_RESULT_FILE})"
-  echo "Test result code is $result"
-  exit $result
-fi
-
-# --run-tests passed as first argument, run the tests.
+initialize $@
 
 # Install Knative Build if not using an existing cluster
-if (( IS_PROW )) || [[ -n ${PROJECT_ID} ]]; then
-  # Make sure we're in the default namespace. Currently kubetest switches to
-  # test-pods namespace when creating the cluster.
-  kubectl config set-context \
-    $(kubectl config current-context) --namespace=default
-
-  header "Starting Knative Build"
-  acquire_cluster_admin_role \
-    $(gcloud config get-value core/account) ${E2E_CLUSTER_NAME} ${E2E_CLUSTER_ZONE}
-  subheader "Installing Istio"
-  kubectl apply -f ${KNATIVE_ISTIO_YAML}
-  wait_until_pods_running istio-system
-  exit_if_test_failed "could not install Istio"
-
-  subheader "Installing Knative Build"
-  kubectl apply -f ${KNATIVE_BUILD_RELEASE}
-  exit_if_test_failed "could not install Knative Build"
-
-  wait_until_pods_running knative-build || exit_if_test_failed
+if (( ! USING_EXISTING_CLUSTER )); then
+  start_latest_knative_build || fail_test
 fi
 
 header "Running tests"
-run_buildpack_test
-exit_if_test_failed
-# TODO(adrcunha): Add more tests.
 
-# kubetest teardown might fail and thus incorrectly report failure of the
-# script, even if the tests pass.
-# We store the real test result to return it later, ignoring any teardown
-# failure in kubetest.
-# TODO(adrcunha): Get rid of this workaround.
-echo -n "0"> ${TEST_RESULT_FILE}
-echo "**************************************"
-echo "***        ALL TESTS PASSED        ***"
-echo "**************************************"
-exit 0
+# TODO(adrcunha): Add more tests.
+run_buildpack_test || fail_test
+
+success

--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -18,6 +18,7 @@
 # It is started by prow for each PR.
 # For convenience, it can also be executed manually.
 
+# Load github.com/knative/test-infra/images/prow-tests/scripts/presubmit-tests.sh
 [ -f /workspace/presubmit-tests.sh ] \
   && source /workspace/presubmit-tests.sh \
   || eval "$(docker run --entrypoint sh gcr.io/knative-tests/test-infra/prow-tests -c 'cat presubmit-tests.sh')"


### PR DESCRIPTION
We're consolidating the test infrastructure into a single place, so all repos get the same fixes, updates and new features.

`e2e-tests.sh` helper was implemented by knative/test-infra#17