### PR TITLE
buildah: successful build template

### DIFF
--- a/buildah/Dockerfile
+++ b/buildah/Dockerfile
@@ -1,11 +1,8 @@
 FROM centos
+ARG RUNC_REVISION="master"
+ARG BUILDAH_REVISION="master"
 
 RUN \
-  # Install runc first, fail fast if something is wrong.
-  yum -y install wget && \
-  wget -O /bin/runc https://github.com/opencontainers/runc/releases/download/v1.0.0-rc5/runc.amd64 && \
-  chmod +x /bin/runc && \
-  runc --help && \
   # Install buildah dependencies.
   yum -y install \
     make \
@@ -27,8 +24,15 @@ RUN \
   mkdir ~/buildah && \
   cd ~/buildah && \
   export GOPATH=`pwd` && \
+  git clone https://github.com/opencontainers/runc ./src/github.com/opencontainers/runc && \
+  cd $GOPATH/src/github.com/opencontainers/runc && \
+  git checkout "${RUNC_REVISION}" && \
+  make runc && \
+  mv runc /usr/bin/runc && \
+  cd $GOPATH/ && \
   git clone https://github.com/projectatomic/buildah ./src/github.com/projectatomic/buildah && \
-  cd ./src/github.com/projectatomic/buildah && \
+  cd $GOPATH/src/github.com/projectatomic/buildah && \
+  git checkout "${BUILDAH_REVISION}" && \
   make && \
   make install && \
   buildah --help

--- a/buildah/buildah.yaml
+++ b/buildah/buildah.yaml
@@ -15,14 +15,20 @@ spec:
   steps:
   - name: build
     image: ${BUILDER_IMAGE}
-    args: ['--storage-driver=vfs', 'bud', '-f', '${DOCKERFILE}', '-t', 'image', '.']
+    args: ['--storage-driver=vfs', 'bud', '--layers', '-f', '${DOCKERFILE}', '-t', '${IMAGE}', '.']
+    env:
+    - name: "BUILDAH_ISOLATION"
+      value: "chroot"
     volumeMounts:
     - name: varlibcontainers
       mountPath: /var/lib/containers
 
   - name: push
     image: ${BUILDER_IMAGE}
-    args: ['--storage-driver=vfs', 'push', 'image', 'docker://${IMAGE}']
+    args: ['--storage-driver=vfs', 'push', '${IMAGE}', 'docker://${IMAGE}']
+    env:
+    - name: "BUILDAH_ISOLATION"
+      value: "chroot"
     volumeMounts:
     - name: varlibcontainers
       mountPath: /var/lib/containers


### PR DESCRIPTION
Recent releases of buildah require newer than repo and newer than latest
tag of runc, so build it from source.
But allow for build-args to the Dockerfile, so you could specify
revisions of runc and buildah as needed.

Building as a limited user inside the container, using userns, is
largely there, but the shadow-utils of centos7 are not. So sticking with
building as uid=0 inside the container for now.

Adding the `--layers` flag with leverage build cache in the volume, if
present.

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>