### PR TITLE
Specify workingDir instead of workingdir in buildpack build template

### DIFF
--- a/buildpack/buildpack.yaml
+++ b/buildpack/buildpack.yaml
@@ -26,7 +26,7 @@ spec:
   - name: build
     image: packs/cf:build
     args: ["-skipDetect=${SKIP_DETECT}", "-buildpackOrder=${BUILDPACK_ORDER}"]
-    workingdir: "${DIRECTORY}"
+    workingDir: "${DIRECTORY}"
     volumeMounts:
     - name: droplet
       mountPath: /out
@@ -37,7 +37,7 @@ spec:
   # Out: an image published as $IMAGE
   - name: export
     image: packs/cf:export
-    workingdir: /in
+    workingDir: /in
     args: ["${IMAGE}"]
     volumeMounts:
     - name: droplet


### PR DESCRIPTION
Attempt to fix https://github.com/knative/build/issues/303

At some point, `workingdir` (lowercase d) worked, but has since stopped working. I'm not sure if it's a Go version thing or a Kubernetes API client thing or a Kubernetes API server thing. This might fix it.

cc @stephen @tanzeeb 

/assign mattmoor