### PR TITLE
buildah: better out-of-the-gate usage

### DIFF
--- a/buildah/Dockerfile
+++ b/buildah/Dockerfile
@@ -37,4 +37,6 @@ RUN \
   make install && \
   buildah --help
 
+ENV BUILDAH_ISOLATION chroot
+ENV STORAGE_DRIVER vfs
 ENTRYPOINT ["buildah"]

--- a/buildah/README.md
+++ b/buildah/README.md
@@ -17,6 +17,8 @@ to assemble a container image, then pushes that image to a container registry.
   (_required_)
 * **DOCKERFILE**: The path to the `Dockerfile` to execute (_default:_
   `./Dockerfile`)
+* **TLSVERIFY**: Verify the TLS on the registry endpoint (for push/pull to a
+  non-TLS registry)
 
 ## Usage
 
@@ -24,7 +26,7 @@ to assemble a container image, then pushes that image to a container registry.
 apiVersion: build.knative.dev/v1alpha1
 kind: Build
 metadata:
-  name: buildah-build
+  name: buildah-build-my-repo
 spec:
   source:
     git:

--- a/buildah/README.md
+++ b/buildah/README.md
@@ -18,7 +18,7 @@ to assemble a container image, then pushes that image to a container registry.
 * **DOCKERFILE**: The path to the `Dockerfile` to execute (_default:_
   `./Dockerfile`)
 * **TLSVERIFY**: Verify the TLS on the registry endpoint (for push/pull to a
-  non-TLS registry)
+  non-TLS registry) (_default:_ `true`)
 
 ## Usage
 

--- a/buildah/buildah.yaml
+++ b/buildah/buildah.yaml
@@ -11,24 +11,21 @@ spec:
   - name: DOCKERFILE
     description: Path to the Dockerfile to build.
     default: ./Dockerfile
+  - name: TLSVERIFY
+    description: Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)
+    default: true
 
   steps:
   - name: build
     image: ${BUILDER_IMAGE}
-    args: ['--storage-driver=vfs', 'bud', '--layers', '-f', '${DOCKERFILE}', '-t', '${IMAGE}', '.']
-    env:
-    - name: "BUILDAH_ISOLATION"
-      value: "chroot"
+    args: ['bud', '--tls-verify=${TLSVERIFY}', '--layers', '-f', '${DOCKERFILE}', '-t', '${IMAGE}', '.']
     volumeMounts:
     - name: varlibcontainers
       mountPath: /var/lib/containers
 
   - name: push
     image: ${BUILDER_IMAGE}
-    args: ['--storage-driver=vfs', 'push', '${IMAGE}', 'docker://${IMAGE}']
-    env:
-    - name: "BUILDAH_ISOLATION"
-      value: "chroot"
+    args: ['push', '--tls-verify=${TLSVERIFY}', '${IMAGE}', 'docker://${IMAGE}']
     volumeMounts:
     - name: varlibcontainers
       mountPath: /var/lib/containers


### PR DESCRIPTION
Some of the env variables are generic enough for now to be included in
the builder_image itself. This will play in for making a non-Dockerfile
build template as well.

As for the `--tls-verify=false`, I'm not pleased with that and will be
working on better specific registry toggling in buildah (that is not
twiddling a TOML file in `/etc/containers/`). Though there is also the
issue of having a conditional provided by kubernetes or knative or from
the end build job of which insecure-registry's are to be set. That is
likely a plumbing discussion to be had

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>