### PR TITLE
Fully-qualifies jib-maven-plugin invocation.

### DIFF
--- a/jib/jib-maven.yaml
+++ b/jib/jib-maven.yaml
@@ -12,6 +12,6 @@ spec:
     image: gcr.io/cloud-builders/mvn
     args:
     - compile
-    - jib:build
+    - com.google.cloud.tools:jib-maven-plugin:build
     - -Duser.home=/builder/home
     - -Dimage=${IMAGE}


### PR DESCRIPTION
Part of #58 

This allows users to build from any Maven project without needing to make any changes to their codebase.