### PR TITLE
Adds DIRECTORY parameter to Jib templates to configure a subdirectory within the source.

### DIFF
--- a/jib/jib-gradle.yaml
+++ b/jib/jib-gradle.yaml
@@ -6,6 +6,9 @@ spec:
   parameters:
   - name: IMAGE
     description: The name of the image to push
+  - name: DIRECTORY
+    description: The directory containing the app, relative to the source repository root
+    default: .
 
   steps:
   - name: build-and-push
@@ -14,3 +17,4 @@ spec:
     - jib
     - -Duser.home=/builder/home
     - --image=${IMAGE}
+    workingDir: /workspace/${DIRECTORY}

--- a/jib/jib-maven.yaml
+++ b/jib/jib-maven.yaml
@@ -6,6 +6,9 @@ spec:
   parameters:
   - name: IMAGE
     description: The name of the image to push
+  - name: DIRECTORY
+    description: The directory containing the app, relative to the source repository root
+    default: .
 
   steps:
   - name: build-and-push
@@ -15,3 +18,4 @@ spec:
     - jib:build
     - -Duser.home=/builder/home
     - -Dimage=${IMAGE}
+    workingDir: /workspace/${DIRECTORY}


### PR DESCRIPTION
Part of #58

`DIRECTORY` here is relative to the root so when configuring it, users do not need to specify the absolute route prefixed with `/workspace`.