### PR TITLE
Adds CACHE to Jib templates to make builds run faster.

### DIFF
--- a/jib/README.md
+++ b/jib/README.md
@@ -13,30 +13,16 @@ to invoke those plugins to build and push container images.
 
 ## Usage (Maven)
 
-This assumes the source repo is using the Maven plugin, configured in your
-`pom.xml`:
-
-```
-<plugin>
-  <groupId>com.google.cloud.tools</groupId>
-  <artifactId>jib-maven-plugin</artifactId>
-  <version>0.9.8</version>
-</plugin>
-```
-
-See [setup instructions for
-Maven](https://github.com/GoogleContainerTools/jib/tree/master/jib-maven-plugin#setup)
-for more information.
-
 To use the `jib-maven` template, first install the template:
 
-```
+```shell
 kubectl apply -f https://raw.githubusercontent.com/knative/build-templates/master/jib/jib-maven.yaml
 ```
 
-Then, define a build that instantiates the template:
+Then, define a `Build` that instantiates the template:
 
-```
+`jib-maven-build.yaml`:
+```yaml
 apiVersion: build.knative.dev/v1alpha1
 kind: Build
 metadata:
@@ -53,14 +39,67 @@ spec:
       value: gcr.io/my-project/my-app
 ```
 
+Run the build:
+
+```shell
+kubectl apply -f jib-maven-build.yaml
+```
+
+If you would like to customize the container, configure the `jib-maven-plugin` in your `pom.xml`. 
+See [setup instructions for Maven](https://github.com/GoogleContainerTools/jib/tree/master/jib-maven-plugin#setup) for more information.
+
+### Speed up builds
+
+Using a persistent volume for caching can speed up your builds. To set up the cache, define a `PersistentVolumeClaim` and attach a corresponding volume to the `Build`:
+
+```yaml
+apiVersion: build.knative.dev/v1alpha1
+kind: Build
+metadata:
+  name: jib-maven-build
+spec:
+  source:
+    git:
+      url: https://github.com/my-user/my-repo
+      revision: master
+  template:
+    name: jib-maven
+    arguments:
+    - name: IMAGE
+      value: gcr.io/my-project/my-app
+    - name: CACHE
+      value: persistent-cache
+
+  volumes:
+  - name: persistent-cache
+    persistentVolumeClaim:
+      claimName: jib-build-cache
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: jib-build-cache
+spec:
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Filesystem
+  resources:
+    requests:
+      storage: 8Gi
+```
+
+This creates a `PersistentVolumeClaim` with 8Gi of storage and attaches it to the build by setting the `CACHE` argument on `spec.template.arguments`.
+
+Future builds should now run much faster.
+
 ## Usage (Gradle)
 
 This assumes the source repo is using the Gradle plugin, configured in
 `build.gradle`:
 
-```
+```groovy
 plugins {
-  id 'com.google.cloud.tools.jib' version '0.9.8'
+  id 'com.google.cloud.tools.jib' version '0.9.10'
 }
 ```
 
@@ -69,13 +108,13 @@ Gradle](https://github.com/GoogleContainerTools/jib/tree/master/jib-gradle-plugi
 
 To use the `jib-gradle` template, first install the template:
 
-```
+```shell
 kubectl apply -f https://raw.githubusercontent.com/knative/build-templates/master/jib/jib-gradle.yaml
 ```
 
 Then, define a build that instantiates the template:
 
-```
+```yaml
 apiVersion: build.knative.dev/v1alpha1
 kind: Build
 metadata:

--- a/jib/README.md
+++ b/jib/README.md
@@ -53,6 +53,18 @@ See [setup instructions for Maven](https://github.com/GoogleContainerTools/jib/t
 Using a persistent volume for caching can speed up your builds. To set up the cache, define a `PersistentVolumeClaim` and attach a corresponding volume to the `Build`:
 
 ```yaml
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: jib-build-cache
+spec:
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Filesystem
+  resources:
+    requests:
+      storage: 8Gi
+---
 apiVersion: build.knative.dev/v1alpha1
 kind: Build
 metadata:
@@ -74,18 +86,6 @@ spec:
   - name: persistent-cache
     persistentVolumeClaim:
       claimName: jib-build-cache
----
-kind: PersistentVolumeClaim
-apiVersion: v1
-metadata:
-  name: jib-build-cache
-spec:
-  accessModes:
-    - ReadWriteOnce
-  volumeMode: Filesystem
-  resources:
-    requests:
-      storage: 8Gi
 ```
 
 This creates a `PersistentVolumeClaim` with 8Gi of storage and attaches it to the build by setting the `CACHE` argument on `spec.template.arguments`.

--- a/jib/jib-gradle.yaml
+++ b/jib/jib-gradle.yaml
@@ -9,6 +9,9 @@ spec:
   - name: DIRECTORY
     description: The directory containing the app, relative to the source repository root
     default: .
+  - name: CACHE
+    description: The name of the volume for caching Maven artifacts and base image layers
+    default: empty-dir-volume
 
   steps:
   - name: build-and-push
@@ -18,3 +21,14 @@ spec:
     - -Duser.home=/builder/home
     - --image=${IMAGE}
     workingDir: /workspace/${DIRECTORY}
+    volumeMounts:
+    - name: ${CACHE}
+      mountPath: /builder/home/.m2
+      subPath: m2-cache
+    - name: ${CACHE}
+      mountPath: /builder/home/.cache
+      subPath: jib-cache
+
+  volumes:
+  - name: empty-dir-volume
+    emptyDir: {}

--- a/jib/jib-maven.yaml
+++ b/jib/jib-maven.yaml
@@ -9,6 +9,9 @@ spec:
   - name: DIRECTORY
     description: The directory containing the app, relative to the source repository root
     default: .
+  - name: CACHE
+    description: The name of the volume for caching Maven artifacts and base image layers
+    default: empty-dir-volume
 
   steps:
   - name: build-and-push
@@ -19,3 +22,14 @@ spec:
     - -Duser.home=/builder/home
     - -Dimage=${IMAGE}
     workingDir: /workspace/${DIRECTORY}
+    volumeMounts:
+    - name: ${CACHE}
+      mountPath: /builder/home/.m2
+      subPath: m2-cache
+    - name: ${CACHE}
+      mountPath: /builder/home/.cache
+      subPath: jib-cache
+
+  volumes:
+  - name: empty-dir-volume
+    emptyDir: {}


### PR DESCRIPTION
Fixes #61 

The cache caches `.m2` for the Maven artifacts and `.cache` for the Jib base image layers cache. This PR also updates the README with some preliminary instructions for using the `CACHE` argument.