### PR TITLE
Add buildpackv3 build-template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Goland
+.idea

--- a/buildpack_v3/README.md
+++ b/buildpack_v3/README.md
@@ -1,0 +1,45 @@
+# Buildpack V3
+
+This build template builds source into a container image using [Cloud Native Buildpacks](https://buildpacks.io).
+
+The Cloud Native Buildpacks website describes v3 buildpacks as:
+
+> ... pluggable, modular tools that translate source code into container-ready artifacts
+> such as OCI images. They replace Dockerfiles in the app development lifecycle with a higher level
+> of abstraction. ...  Cloud Native Buildpacks embrace modern container standards, such as the OCI
+> image format. They take advantage of the latest capabilities of these standards, such as remote
+> image layer rebasing on Docker API v2 registries.
+
+**Note**: This Buildpack v3 template is distinct from Buildpack.
+
+## Create the template
+
+```
+kubectl apply -f https://raw.githubusercontent.com/knative/build-templates/master/buildpack_v3/template.yaml
+```
+
+## Parameters
+
+* **IMAGE:** The Docker image name to apply to the newly built image.
+    (_required_)
+* **RUN_IMAGE:** The run image buildpacks will use as the base for IMAGE.
+* **USE_CREDENTIAL_HELPERS:** Use Docker credential helpers. Set to `"true"` or `"false"` as string values.
+
+## Usage
+
+```
+apiVersion: build.knative.dev/v1alpha1
+kind: Build
+metadata:
+  name: buildpackv3-example-build
+spec:
+  source:
+    git:
+      url: https://github.com/my-user/my-repo
+      revision: master
+  template:
+    name: buildpackv3
+    arguments:
+    - name: IMAGE
+      value: us.gcr.io/my-project/my-app
+```

--- a/buildpack_v3/template.yaml
+++ b/buildpack_v3/template.yaml
@@ -1,0 +1,83 @@
+---
+apiVersion: build.knative.dev/v1alpha1
+kind: BuildTemplate
+metadata:
+  name: buildpackv3
+spec:
+  parameters:
+  - name: IMAGE
+    description: The image you wish to create. For example, "repo/example", or "example.com/repo/image".
+  - name: RUN_IMAGE # TODO: add more options when Build permits
+    description: The run image buildpacks will use as the base for IMAGE.
+    default: packs/v3:run
+  - name: USE_CREDENTIAL_HELPERS
+    description: Use Docker credential helpers for Google's GCR, Amazon's ECR or Microsoft's ACR.
+    default: 'true'
+
+  steps:
+  - name: chown-home-workspace
+    image: packs/v3:latest
+    command: ["chown", "-R", "packs", "/builder/home", "/workspace"]
+  - name: copy-app
+    image: packs/v3:detect
+    command: ["cp", "-R", "/workspace", "/launch/app"]
+    volumeMounts:
+    - name: launch
+      mountPath: /launch
+    imagePullPolicy: Always
+  - name: detect
+    image: packs/v3:detect
+    workingDir: /lifecycleworkspace # Build creates a /workspace, which buildpacks tries to use for a different purpose.
+    volumeMounts:
+    - name: lifecycleworkspace
+      mountPath: /lifecycleworkspace
+    - name: launch
+      mountPath: /launch
+    imagePullPolicy: Always
+  - name: analyze
+    image: packs/v3:analyze
+    args: ["${IMAGE}"]
+    env:
+    - name: PACK_USE_HELPERS
+      value: ${USE_CREDENTIAL_HELPERS}
+    workingDir: /lifecycleworkspace
+    volumeMounts:
+    - name: lifecycleworkspace
+      mountPath: /lifecycleworkspace
+    - name: launch
+      mountPath: /launch
+    imagePullPolicy: Always
+  - name: build
+    image: packs/v3:build
+    workingDir: /lifecycleworkspace
+    volumeMounts:
+    - name: lifecycleworkspace
+      mountPath: /lifecycleworkspace
+    - name: launch
+      mountPath: /launch
+    - name: cache
+      mountPath: /cache
+    imagePullPolicy: Always
+  - name: export
+    image: packs/v3:export
+    args: ["${IMAGE}"]
+    env:
+    - name: PACK_RUN_IMAGE
+      value: ${RUN_IMAGE}
+    - name: PACK_USE_HELPERS
+      value: ${USE_CREDENTIAL_HELPERS}
+    workingDir: /lifecycleworkspace
+    volumeMounts:
+    - name: lifecycleworkspace
+      mountPath: /lifecycleworkspace
+    - name: launch
+      mountPath: /launch
+    imagePullPolicy: Always
+
+  volumes:
+  - name: launch
+    emptyDir: {}
+  - name: lifecycleworkspace
+    emptyDir: {}
+  - name: cache
+    emptyDir: {}


### PR DESCRIPTION
This PR introduces preliminary support for [Cloud Native Buildpacks](https://buildpacks.io), aka buildpacks v3.