### PR TITLE
Updates Jib template README with new parameters.

### DIFF
--- a/jib/README.md
+++ b/jib/README.md
@@ -1,15 +1,34 @@
 # Jib
 
-This build template builds source into a container image using Google's
-[Jib](https://github.com/GoogleContainerTools/jib) tool.
+This build template builds Java/Kotlin/Groovy/Scala source into a container image using Google's [Jib](https://github.com/GoogleContainerTools/jib) tool.
 
-Jib provides both a
-[Maven](https://github.com/GoogleContainerTools/jib/tree/master/jib-maven-plugin)
-and a
-[Gradle](https://github.com/GoogleContainerTools/jib/tree/master/jib-gradle-plugin)
-plugin, and this template comes in two flavors,
-[`jib-maven.yaml`](./jib-maven.yaml) and [`jib-gradle.yaml`](./jib-gradle.yaml),
-to invoke those plugins to build and push container images.
+Jib works with [Maven](https://github.com/GoogleContainerTools/jib/tree/master/jib-maven-plugin) and [Gradle](https://github.com/GoogleContainerTools/jib/tree/master/jib-gradle-plugin) projects, and this template comes in two flavors, [`jib-maven.yaml`](./jib-maven.yaml) for Maven projects and [`jib-gradle.yaml`](./jib-gradle.yaml) for Gradle projects.
+
+## Create the template
+
+Maven:
+
+```shell
+kubectl apply -f https://raw.githubusercontent.com/knative/build-templates/master/jib/jib-maven.yaml
+```
+
+Gradle:
+
+```shell
+kubectl apply -f https://raw.githubusercontent.com/knative/build-templates/master/jib/jib-gradle.yaml
+```
+
+## Parameters
+
+- **IMAGE**: The Docker image name to apply to the newly built image. (*required*)
+- **DIRECTORY**: The directory in the source repository where source should be found. (*default: .*)
+- **CACHE**: The name of the volume for caching Maven artifacts and base image layers (*default: empty-dir-volume*)
+
+## ServiceAccount
+
+Jib builds an image and pushes it to the destination defined as the **IMAGE** parameter. In order to properly authenticate to the remote container registry, the build needs to have the proper credentials. This is achieved using a build `ServiceAccount`.
+
+For an example on how to create such a `ServiceAccount`, see the [Authentication](https://github.com/knative/docs/blob/master/build/auth.md#basic-authentication-docker) documentation page.
 
 ## Usage (Maven)
 


### PR DESCRIPTION
Note that the CACHE parameter will be valid after #64 is merged.

The `Usage` sections will be updated after #64 is merged.