### PR TITLE
Jib: Adds init script to use with any Gradle project.

### DIFF
--- a/jib/README.md
+++ b/jib/README.md
@@ -113,26 +113,15 @@ Future builds should now run much faster.
 
 ## Usage (Gradle)
 
-This assumes the source repo is using the Gradle plugin, configured in
-`build.gradle`:
-
-```groovy
-plugins {
-  id 'com.google.cloud.tools.jib' version '0.9.10'
-}
-```
-
-See [setup instructions for
-Gradle](https://github.com/GoogleContainerTools/jib/tree/master/jib-gradle-plugin#setup).
-
 To use the `jib-gradle` template, first install the template:
 
 ```shell
 kubectl apply -f https://raw.githubusercontent.com/knative/build-templates/master/jib/jib-gradle.yaml
 ```
 
-Then, define a build that instantiates the template:
+Then, define a `Build` that instantiates the template:
 
+`jib-gradle-build.yaml`:
 ```yaml
 apiVersion: build.knative.dev/v1alpha1
 kind: Build
@@ -149,3 +138,16 @@ spec:
     - name: IMAGE
       value: gcr.io/my-project/my-app
 ```
+
+Run the build:
+
+```shell
+kubectl apply -f jib-gradle-build.yaml
+```
+
+If you would like to customize the container, configure the `jib-gradle-plugin` in your `pom.xml`. 
+See [setup instructions for Gradle](https://github.com/GoogleContainerTools/jib/tree/master/jib-gradle-plugin#setup) for more information.
+
+### Speed up builds
+
+See [Speed up builds](#speed-up-builds).

--- a/jib/jib-gradle.yaml
+++ b/jib/jib-gradle.yaml
@@ -16,15 +16,49 @@ spec:
   steps:
   - name: build-and-push
     image: gcr.io/cloud-builders/gradle
+    command:
+    - sh
+    - -c
     args:
-    - jib
-    - -Duser.home=/builder/home
-    - --image=${IMAGE}
+    - |
+      # Adds Gradle init script that applies the Jib Gradle plugin.
+      echo "\
+      initscript {
+        repositories {
+          maven {
+            url 'https://plugins.gradle.org/m2'
+          }
+        }
+        dependencies {
+          classpath 'gradle.plugin.com.google.cloud.tools:jib-gradle-plugin:+'
+        }
+      }
+
+      // Only applies the Jib plugin if the project does not apply it already.
+      rootProject {
+        afterEvaluate {
+          if (!project.plugins.hasPlugin('com.google.cloud.tools.jib')) {
+            project.apply plugin: com.google.cloud.tools.jib.gradle.JibPlugin
+          }
+        }
+      }\
+      " > /builder/home/auto-jib.gradle
+
+      # Runs the Gradle Jib build.
+      gradle jib \
+        --init-script=/builder/home/auto-jib.gradle \
+        -Dgradle.user.home=/builder/home/.gradle \
+        -Duser.home=/builder/home \
+        --image=${IMAGE}
+
     workingDir: /workspace/${DIRECTORY}
     volumeMounts:
     - name: ${CACHE}
-      mountPath: /builder/home/.m2
-      subPath: m2-cache
+      mountPath: /builder/home/.gradle/caches
+      subPath: gradle-caches
+    - name: ${CACHE}
+      mountPath: /builder/home/.gradle/wrapper
+      subPath: gradle-wrapper
     - name: ${CACHE}
       mountPath: /builder/home/.cache
       subPath: jib-cache


### PR DESCRIPTION
Fixes #63 

The init script auto-applies `jib-gradle-plugin` to the Gradle project.
Also fixes the caching for the `jib-gradle` `BuildTemplate`.

/cc loosebazooka
/cc saturnism
