### PR TITLE
buildah: convert Dockerfile to a multi-stage build

### DIFF
--- a/buildah/Dockerfile
+++ b/buildah/Dockerfile
@@ -25,6 +25,7 @@ RUN mkdir ~/runc && \
   git clone https://github.com/opencontainers/runc ./src/github.com/opencontainers/runc && \
   cd $GOPATH/src/github.com/opencontainers/runc && \
   git checkout "${RUNC_REVISION}" && \
+  git log -1 --oneline > /.version.runc && \
   make runc && \
   mv runc /usr/bin/runc
 
@@ -45,8 +46,17 @@ RUN mkdir ~/buildah && \
   make install
 
 FROM centos:7
-RUN yum -y install libarchive ostree lzo libseccomp libedit gpgme
+RUN yum -y install libarchive ostree lzo libseccomp libedit gpgme && \
+  yam clean all && \
+  rm -rf \
+    /var/cache/yum \
+    /usr/share/doc \
+    /usr/share/man \
+    /usr/share/info \
+    /usr/share/locale \
+    /var/log/*
 COPY --from=runc /usr/bin/runc /usr/bin/runc
+COPY --from=runc /.version.runc /.version.runc
 COPY --from=buildah /usr/local/bin/buildah /usr/bin/buildah
 COPY --from=buildah /etc/containers /etc/containers
 ENV BUILDAH_ISOLATION chroot

--- a/buildah/Dockerfile
+++ b/buildah/Dockerfile
@@ -1,7 +1,4 @@
-FROM centos
-ARG RUNC_REVISION="master"
-ARG BUILDAH_REVISION="master"
-
+FROM centos:7 as base
 RUN \
   # Install buildah dependencies.
   yum -y install \
@@ -16,27 +13,42 @@ RUN \
     libseccomp-devel \
     ostree-devel \
     git \
-    bzip2 \
-    go-md2man \
-    runc \
-    skopeo-containers && \
-  # Install buildah.
-  mkdir ~/buildah && \
-  cd ~/buildah && \
+    bzip2
+
+FROM base as runc
+ARG RUNC_REVISION="master"
+
+RUN yum -y install runc
+RUN mkdir ~/runc && \
+  cd ~/runc && \
   export GOPATH=`pwd` && \
   git clone https://github.com/opencontainers/runc ./src/github.com/opencontainers/runc && \
   cd $GOPATH/src/github.com/opencontainers/runc && \
   git checkout "${RUNC_REVISION}" && \
   make runc && \
-  mv runc /usr/bin/runc && \
+  mv runc /usr/bin/runc
+
+FROM base as buildah
+ARG BUILDAH_REVISION="master"
+RUN yum -y install \
+    go-md2man \
+    runc \
+    skopeo-containers
+RUN mkdir ~/buildah && \
+  cd ~/buildah && \
+  export GOPATH=`pwd` && \
   cd $GOPATH/ && \
   git clone https://github.com/containers/buildah ./src/github.com/containers/buildah && \
   cd $GOPATH/src/github.com/containers/buildah && \
   git checkout "${BUILDAH_REVISION}" && \
   make && \
-  make install && \
-  buildah --help
+  make install
 
+FROM centos:7
+RUN yum -y install libarchive ostree lzo libseccomp libedit gpgme
+COPY --from=runc /usr/bin/runc /usr/bin/runc
+COPY --from=buildah /usr/local/bin/buildah /usr/bin/buildah
+COPY --from=buildah /etc/containers /etc/containers
 ENV BUILDAH_ISOLATION chroot
 ENV STORAGE_DRIVER vfs
 ENTRYPOINT ["buildah"]

--- a/buildah/README.md
+++ b/buildah/README.md
@@ -51,7 +51,8 @@ to change in the future. You can build the image from [the Dockerfile in this
 directory](./Dockerfile), e.g.:
 
 ```
-docker build -t buildah . && docker push buildah
+docker build -t <user>/buildah . && docker push <user>/buildah
 ```
 
-(You could also build the image using `buildah` itself, or `kaniko`)
+You need a relatively recent version of Docker (>= 17.05).
+You could also build the image using `buildah` itself, or `kaniko`


### PR DESCRIPTION
It makes the final image smaller, and allow better caching when
building it. It also updates the `README.md` and sets a default
builder image for buildah (`vdemeester/buildah-builder` that is
automatically build on the docker hub).

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>