### PR TITLE
Add s2i (source-to-image) build template

### DIFF
--- a/s2i/Dockerfile
+++ b/s2i/Dockerfile
@@ -1,0 +1,20 @@
+FROM centos:7 as build
+RUN yum -y install \
+    make \
+    golang \
+    git \
+    bzip2
+ARG S2I_REVISION="v1.1.12"
+RUN mkdir ~/s2i && \
+  go version && \
+  cd ~/s2i && \
+  export GOPATH=`pwd` && \
+  cd $GOPATH/ && \
+  git clone https://github.com/openshift/source-to-image ./src/github.com/openshift/source-to-image && \
+  cd $GOPATH/src/github.com/openshift/source-to-image && \
+  git checkout "${S2I_REVISION}" && \
+  go build -o /usr/local/bin/s2i ./cmd/s2i
+
+FROM centos:7
+COPY --from=build /usr/local/bin/s2i /usr/bin/s2i
+ENTRYPOINT [ "s2i", "build", "--as-dockerfile=Dockerfile" ]

--- a/s2i/README.md
+++ b/s2i/README.md
@@ -1,0 +1,65 @@
+# Source-to-image (a.k.a. `s2i`)
+
+This build template builds source into a container image using
+Openshift [`source-to-image`](https://github.com/openshift/source-to-image)
+build tool.
+
+> Source-to-Image (S2I) is a toolkit and workflow for building
+> reproducible Docker images from source code. S2I produces
+> ready-to-run images by injecting source code into a Docker container
+> and letting the container prepare that source code for execution. By
+> creating self-assembling builder images, you can version and control
+> your build environments exactly like you use Docker images to
+> version your runtime environments.
+
+This build template uses `s2i` support for generating a `Dockerfile`
+and a build context, that can be later build by [`buildah`](https://github.com/containers/buildah).
+This allows user to have, *somewhat*, similar builds as Openshift
+[`Source-to-Image` build stragety](https://docs.openshift.com/container-platform/3.11/architecture/core_concepts/builds_and_image_streams.html#source-build)
+
+## Parameters
+
+* **BUILDER_IMAGE** : The name of the image containing the `s2i` tool
+* **BUILDAH_BUILDER_IMAGE** : The name of the image containing the
+  `buildah` tool (_default:_ docker.io/vdemeester/buildah-builder)
+* **IMAGE**: The Docker image name to apply to the newly built image.
+  (_required_)
+* **BASE_IMAGE**: The base image to use with `s2i` to build from.
+  (_required_)
+* **TLSVERIFY**: Verify the TLS on the registry endpoint (for push/pull to a
+  non-TLS registry) (_default:_ `true`)
+
+## Usage
+
+```
+apiVersion: build.knative.dev/v1alpha1
+kind: Build
+metadata:
+  name: s2i-build-my-repo
+spec:
+  source:
+    git:
+      url: https://github.com/OpenShiftDemos/os-sample-python # replace with your s2i-compatible repository
+      revision: master
+  template:
+    name: s2i
+    arguments:
+    - name: BASE_IMAGE
+      value: centos/python-36-centos7
+    - name: IMAGE
+      value: gcr.io/my-project/my-app
+```
+
+In this example, the Git repo being built is expected to be a python project
+
+## Note: *_BUILDER_IMAGE
+
+Currently, you must build and host the builder image yourself. This is expected
+to change in the future. You can build the images (for `s2i`
+and `buildah`) from the `Dockerfile`(s)
+([`Dockerfile`](./Dockerfile) and
+[`../buildah/Dockerfile`](../buildah/Dockerfile)), e.g.:
+
+```
+docker build -t s2i -f Dockerfile . && docker push s2i
+```

--- a/s2i/s2i.yaml
+++ b/s2i/s2i.yaml
@@ -1,0 +1,47 @@
+apiVersion: build.knative.dev/v1alpha1
+kind: BuildTemplate
+metadata:
+  name: s2i
+spec:
+  parameters:
+  - name: S2I_BUILDER_IMAGE
+    description: The location of the s2i builder image.
+  - name: BUILDAH_BUILDER_IMAGE
+    description: The location of the buildah builder image.
+  - name: IMAGE
+    description: The name of the image to push.
+  - name: BASE_IMAGE
+    description: The base image to use with `s2i` to build from.
+  - name: TLSVERIFY
+    description: Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)
+    default: "true"
+
+  steps:
+  - name: generate
+    image: ${S2I_BUILDER_IMAGE}
+    args: ['/workspace', '${BASE_IMAGE}', '${IMAGE}']
+    workingDir: /sources
+    volumeMounts:
+    - name: generatedsources
+      mountPath: /sources
+  - name: build
+    image: ${BUILDAH_BUILDER_IMAGE}
+    args: ['bud', '--tls-verify=${TLSVERIFY}', '--layers', '-f', 'Dockerfile', '-t', '${IMAGE}', '.']
+    workingDir: /sources
+    volumeMounts:
+    - name: generatedsources
+      mountPath: /sources
+    - name: varlibcontainers
+      mountPath: /var/lib/containers
+  - name: push
+    image: ${BUILDAH_BUILDER_IMAGE}
+    args: ['push', '--tls-verify=${TLSVERIFY}', '${IMAGE}', 'docker://${IMAGE}']
+    volumeMounts:
+    - name: varlibcontainers
+      mountPath: /var/lib/containers
+
+  volumes:
+  - name: varlibcontainers
+    emptyDir: {}
+  - name: generatedsources
+    emptyDir: {}


### PR DESCRIPTION
This allows user to have similar build as Openshift source strategy
build config.

> Source-to-Image (S2I) is a toolkit and workflow for building
> reproducible Docker images from source code. S2I produces
> ready-to-run images by injecting source code into a Docker container
> and letting the container prepare that source code for execution. By
> creating self-assembling builder images, you can version and control
> your build environments exactly like you use Docker images to
> version your runtime environments.

cc @bbrowning @vbatts 

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>