### PR TITLE
Unset IFS to avoid quoting issues

### DIFF
--- a/ecr_helper/helper.sh
+++ b/ecr_helper/helper.sh
@@ -92,6 +92,7 @@ IFS=:
 set -- $TOKEN
 USERNAME=$1
 PASSWORD=$2
+unset IFS
 
 if [[ -z $USERNAME ]]; then
     echo "got empty username"


### PR DESCRIPTION
When executing the `ecr_helper.sh` (on Ubuntu 18.04 with GNU bash version 4.4.19(1)-release) we get an error due to quoting issues caused by manipulating the Internal Field Separator:
```
$ ecr_helper.sh ecr-test ecr-service-account
Error: unknown command " -n ecr-test" for "kubectl"
Run 'kubectl --help' for usage.
unknown command " -n ecr-test" for "kubectl"
```

To fix this issue, we simply `unset IFS` as soon as username and password have been parsed from the token.
