### PR TITLE
Optionally add pull secret for private ECR

### DIFF
--- a/ecr_helper/README.md
+++ b/ecr_helper/README.md
@@ -6,7 +6,6 @@ By default, the following resources will be provisioned:
 
 * A Kubernetes service account (named `builder` by default) with secrets (`ecr-creds`) to enable pushing to ECR.
 
-
 To use, simply add a `serviceAccountName: builder` entry to your build definition
 
 ```yaml:
@@ -35,6 +34,12 @@ the namespace and kubernetes service account used:
 
 ```shell
 ecr_helper/helper.sh $MY_NAMESPACE builder-serviceaccount
+```
+
+Optionally, a pull secret can be added to the service account which enables pulling images from a private ECR.
+
+```shell
+ecr_helper/helper.sh --push-and-pull <namespace> <serviceaccount>
 ```
 
 This will output a log of operations performed or skipped:

--- a/ecr_helper/helper.sh
+++ b/ecr_helper/helper.sh
@@ -53,6 +53,11 @@ checkBinary aws
 checkBinary jq
 checkBinary kubectl
 
+if [[ "$1" == "--push-and-pull" ]]; then
+  PUSH_AND_PULL_SECRETS=true
+  shift
+fi
+
 readonly KUBECTL_FLAGS="${1:+ -n $1}"
 
 if ! kubectl $KUBECTL_FLAGS get sa >& /dev/null; then
@@ -103,6 +108,25 @@ if [[ -z $PASSWORD ]]; then
     exit 1
 fi
 
+if [[ -n "$PUSH_AND_PULL_SECRETS" ]]; then
+  OPTIONAL_IMAGE_PULL_SECRETS=$(cat <<EOF
+imagePullSecrets:
+- name: ecr-creds-pull
+EOF
+)
+  OPTIONAL_PULL_SECRET=$(cat <<EOF
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ecr-creds-pull
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: $(echo -n "{\"auths\":{\"$ENDPOINT\":{\"Username\":\"$USERNAME\",\"Password\":\"$PASSWORD\",\"Email\":\"noop\"}}}" | openssl base64 -a -A)
+EOF
+)
+fi
+
 cat <<EOF | kubectl $KUBECTL_FLAGS apply -f - 2>&3
 apiVersion: v1
 kind: ServiceAccount
@@ -110,6 +134,7 @@ metadata:
   name: $KUBE_SA
 secrets:
 - name: ecr-creds
+$OPTIONAL_IMAGE_PULL_SECRETS
 ---
 apiVersion: v1
 kind: Secret
@@ -121,6 +146,7 @@ type: kubernetes.io/basic-auth
 data:
   username: $(echo -n $USERNAME | openssl base64 -a -A)
   password: $(echo -n $PASSWORD | openssl base64 -a -A)
+$OPTIONAL_PULL_SECRET
 EOF
 
 readonly EXIT=$?


### PR DESCRIPTION
While testing with a private ECR, we figured out that the `ecr_helper.sh` script does not create the necessary pull secret of type `kubernetes.io/dockerconfigjson`. We added an optional flag `--push-and-pull` to the helper script to support private ECRs.
