### PR TITLE
Add flag to disable the use of credential helpers

### DIFF
--- a/buildpack/README.md
+++ b/buildpack/README.md
@@ -27,6 +27,8 @@ kubectl apply -f https://raw.githubusercontent.com/knative/build-templates/maste
     should be found. (_default:_ `/workspace`)
 * **CACHE:** The directory where data should be persistently cached
     between builds. (_default:_ `app-cache`)
+* **USE_CRED_HELPERS:** Use Docker credential helpers for Google's GCR, Amazon's
+    ECR, or Microsoft's ACR. (_default:_ `"true"`)
 
 ## Usage
 

--- a/buildpack/buildpack.yaml
+++ b/buildpack/buildpack.yaml
@@ -18,6 +18,9 @@ spec:
   - name: CACHE
     description: The name of the persistent app cache volume
     default: app-cache
+  - name: USE_CRED_HELPERS
+    description: Use Docker credential helpers for Google's GCR, Amazon's ECR, or Microsoft's ACR.
+    default: "true"
 
   steps:
   # In: a CF app in $DIRECTORY
@@ -39,6 +42,9 @@ spec:
     image: packs/cf:export
     workingDir: /in
     args: ["${IMAGE}"]
+    env:
+    - name: PACK_USE_HELPERS
+      value: "${USE_CRED_HELPERS}"
     volumeMounts:
     - name: droplet
       mountPath: /in


### PR DESCRIPTION
By default the docker credential helpers for GCP, AWS, and Azure were used, while provided docker credentials were ignored. Setting the template argument USE_EXPORT_CREDENTIAL_HELPERS to false will override the default value of PACK_USE_HELPERS in packs/cf:export.