### PR TITLE
Pin to kaniko v0.1.0

### DIFF
--- a/kaniko/kaniko.yaml
+++ b/kaniko/kaniko.yaml
@@ -12,7 +12,10 @@ spec:
 
   steps:
   - name: build-and-push
-    image: gcr.io/kaniko-project/executor
+    # Newer versions of kaniko expect credentials outside of ~/.docker/config
+    # Pin to v0.1.0 until
+    # https://github.com/GoogleContainerTools/kaniko/issues/392 is resolved
+    image: gcr.io/kaniko-project/executor:v0.1.0
     args:
     - --dockerfile=${DOCKERFILE}
     - --destination=${IMAGE}


### PR DESCRIPTION
Fixes #85 

Pin Kaniko to v0.1.0 until https://github.com/GoogleContainerTools/kaniko/issues/392 is fixed.