### PR TITLE
Explicitly set DOCKER_CONFIG in the kaniko build template.

### DIFF
--- a/kaniko/kaniko.yaml
+++ b/kaniko/kaniko.yaml
@@ -12,10 +12,10 @@ spec:
 
   steps:
   - name: build-and-push
-    # Newer versions of kaniko expect credentials outside of ~/.docker/config
-    # Pin to v0.1.0 until
-    # https://github.com/GoogleContainerTools/kaniko/issues/392 is resolved
-    image: gcr.io/kaniko-project/executor:v0.1.0
+    image: gcr.io/kaniko-project/executor
     args:
     - --dockerfile=${DOCKERFILE}
     - --destination=${IMAGE}
+    env:
+    - name: DOCKER_CONFIG
+      value: /builder/home/.docker


### PR DESCRIPTION
This resolves Kaniko issue #392 and knative/build issue #414.
At some point, Kaniko started explicitly setting DOCKER_CONFIG so google/go-containerregistry
would use the injected credential helpers. This behavior is ideal in some cases, but inside
knative we want to use the auto-injected auth token directly.