### PR TITLE
Add BuildTemplate for makisu

### DIFF
--- a/makisu/README.md
+++ b/makisu/README.md
@@ -65,7 +65,7 @@ spec:
 
 ### Other Registries
 
-**The PUSH_REGISTRY must match the name of the registry specified in the registry.yaml**
+The `PUSH_REGISTRY` **must** match the name of the registry specified in the registry.yaml
 
 ```yaml
 apiVersion: build.knative.dev/v1alpha1

--- a/makisu/README.md
+++ b/makisu/README.md
@@ -41,13 +41,17 @@ Write a `Build` manifest and use the `template` section to refer to the makisu
 build template. Set the value of the parameters such as the destination Docker
 image.
 
-```
+In this example, the Git repo being built is expected to have a `Dockerfile` at
+the root of the repository.
+
+### Docker Registry
+
+```yaml
 apiVersion: build.knative.dev/v1alpha1
 kind: Build
 metadata:
   name: makisu-build
 spec:
-  serviceAccountName: makisu-build
   source:
     git:
       url: https://github.com/my-user/my-repo
@@ -56,8 +60,30 @@ spec:
     name: makisu
     arguments:
     - name: IMAGE
-      value: us.gcr.io/my-project/my-app
+      value: my-project/my-app
 ```
 
-In this example, the Git repo being built is expected to have a `Dockerfile` at
-the root of the repository.
+### Other Registries
+
+**The PUSH_REGISTRY must match the name of the registry specified in the registry.yaml**
+
+```yaml
+apiVersion: build.knative.dev/v1alpha1
+kind: Build
+metadata:
+  name: makisu-build-gcr
+spec:
+  source:
+    git:
+      url: https://github.com/my-user/my-repo
+      revision: master
+  template:
+    name: makisu
+    arguments:
+    - name: IMAGE
+      value: eu.gcr.io/gke-on-premise-inovex
+    - name: PUSH_REGISTRY # must match the registry in the secret
+      value: eu.gcr.io
+    - name: REGISTRY_SECRET
+      value: gcr-registry-config
+```

--- a/makisu/README.md
+++ b/makisu/README.md
@@ -33,7 +33,7 @@ kubectl apply -f https://raw.githubusercontent.com/knative/build-templates/maste
 * **PUSH_REGISTRY**: The Registry to push the image to (_default:_
   `index.docker.io`)
 * **REGISTRY_SECRET**: Secret containing information about the used regsitry (_default:_
-  `docker-registry-config`) **This Parameter currently doesn't work: https://github.com/knative/build/pull/550**
+  `docker-registry-config`)
 
 ## Usage
 

--- a/makisu/README.md
+++ b/makisu/README.md
@@ -1,0 +1,63 @@
+# makisu
+
+This build template builds source into a container image using uber's
+[`makisu`](https://github.com/uber/makisu) tool.
+
+>Makisu is a fast and flexible Docker image build tool designed for unprivileged
+>containerized environments such as Mesos or Kubernetes.
+> - [makisu website](https://github.com/uber/makisu)
+
+makisu is meant to be run as an image, `gcr.io/makisu-project/makisu`. This
+makes it a perfect tool to be part of a Knative build.
+
+## Create the registry configuration
+
+makisu uses a [registry configuration](https://github.com/uber/makisu/blob/master/docs/REGISTRY.md) which should be stored as a secret in Kubernetes. Adjust the `registry.yaml` in this diretroy to contain your user and password for the Docker hub (or configure a different [registry](https://github.com/uber/makisu/blob/master/docs/REGISTRY.md#examples)). Keep in mind that the secret must exist in the same namespace as the build runs.:
+
+```bash
+kubectl --namespace default create secret generic docker-registry-config --from-file=./registry.yaml
+```
+
+## Create the template
+
+```
+kubectl apply -f https://raw.githubusercontent.com/knative/build-templates/master/makisu/makisu.yaml
+```
+
+## Parameters
+
+* **IMAGE**: The Docker image name to apply to the newly built image.
+  (_required_)
+* **CONTEXTPATH**: The path to the build context (_default:_
+  `/workspace`)
+* **PUSH_REGISTRY**: The Registry to push the image to (_default:_
+  `index.docker.io`)
+* **REGISTRY_SECRET**: Secret containing information about the used regsitry (_default:_
+  `docker-registry-config`) **This Parameter currently doesn't work: https://github.com/knative/build/pull/550**
+
+## Usage
+
+Write a `Build` manifest and use the `template` section to refer to the makisu
+build template. Set the value of the parameters such as the destination Docker
+image.
+
+```
+apiVersion: build.knative.dev/v1alpha1
+kind: Build
+metadata:
+  name: makisu-build
+spec:
+  serviceAccountName: makisu-build
+  source:
+    git:
+      url: https://github.com/my-user/my-repo
+      revision: master
+  template:
+    name: makisu
+    arguments:
+    - name: IMAGE
+      value: us.gcr.io/my-project/my-app
+```
+
+In this example, the Git repo being built is expected to have a `Dockerfile` at
+the root of the repository.

--- a/makisu/makisu.yaml
+++ b/makisu/makisu.yaml
@@ -12,16 +12,16 @@ spec:
   - name: PUSH_REGISTRY
     description: Registry to push image to.
     default: index.docker.io
-  # ToDo currently not possible see: https://github.com/knative/build/pull/550
   - name: REGISTRY_SECRET
     description: Secret containing information about the used regsitry.
     default: docker-registry-config
   steps:
   - name: build-and-push
-    image: gcr.io/makisu-project/makisu:v0.1.8
+    image: gcr.io/makisu-project/makisu:v0.1.9
     args:
       - build
-      - --push=${PUSHREGISTRY}
+      - --push=${PUSH_REGISTRY}
+      - --registry-config=/registry-config
       - --modifyfs=true
       - --tag=${IMAGE}
       - --registry-config=/registry-config/registry.yaml
@@ -35,5 +35,4 @@ spec:
   volumes:
   - name: registry-config
     secret:
-      # ToDo currently not possible ${REGISTRY_SECRET}
-      secretName: docker-registry-config
+      secretName: ${REGISTRY_SECRET}

--- a/makisu/makisu.yaml
+++ b/makisu/makisu.yaml
@@ -1,0 +1,39 @@
+apiVersion: build.knative.dev/v1alpha1
+kind: BuildTemplate
+metadata:
+  name: makisu
+spec:
+  parameters:
+  - name: IMAGE
+    description: The name of the image to push
+  - name: CONTEXTPATH
+    description: Path to the build context.
+    default: /workspace
+  - name: PUSH_REGISTRY
+    description: Registry to push image to.
+    default: index.docker.io
+  # ToDo currently not possible see: https://github.com/knative/build/pull/550
+  - name: REGISTRY_SECRET
+    description: Secret containing information about the used regsitry.
+    default: docker-registry-config
+  steps:
+  - name: build-and-push
+    image: gcr.io/makisu-project/makisu:v0.1.8
+    args:
+      - build
+      - --push=${PUSHREGISTRY}
+      - --modifyfs=true
+      - --tag=${IMAGE}
+      - --registry-config=/registry-config/registry.yaml
+      - ${CONTEXTPATH}
+    env:
+    - name: DOCKER_CONFIG
+      value: /builder/home/.docker
+    volumeMounts:
+    - name: registry-config
+      mountPath: /registry-config
+  volumes:
+  - name: registry-config
+    secret:
+      # ToDo currently not possible ${REGISTRY_SECRET}
+      secretName: docker-registry-config

--- a/makisu/registry.yaml
+++ b/makisu/registry.yaml
@@ -1,0 +1,9 @@
+index.docker.io:
+  .*:
+    security:
+      tls:
+        client:
+          disabled: false
+      basic:
+        username: ""
+        password: ""


### PR DESCRIPTION
This PR adds a simple BuildTemplate for makisu (https://github.com/uber/makisu). As soon as https://github.com/knative/build/pull/550 gets merged I would adjust the Secret Volume to be rendered by a Template Parameter rather than a hardcoded string.

Currently the makisu setup doesn't use a global build cache (mentioned here: https://github.com/uber/makisu#using-cache) if you want I can add an example for the global cache too.

Fixes: https://github.com/knative/build-templates/issues/77 