### PR TITLE
Add context for kaniko

### DIFF
--- a/kaniko/README.md
+++ b/kaniko/README.md
@@ -24,6 +24,8 @@ kubectl apply -f https://raw.githubusercontent.com/knative/build-templates/maste
   (_required_)
 * **DOCKERFILE**: The path to the `Dockerfile` to execute (_default:_
   `./Dockerfile`)
+* **CONTEXT**: Kaniko [build context](https://github.com/GoogleContainerTools/kaniko#kaniko-build-contexts)
+  (_default:_  `/workspace`)
 
 ## ServiceAccount
 
@@ -60,7 +62,11 @@ spec:
     arguments:
     - name: IMAGE
       value: us.gcr.io/my-project/my-app
+    - name: DOCKERFILE
+      value: ./Dockerfile
+    - name: CONTEXT
+      value: /workspace/myfolder
 ```
 
-In this example, the Git repo being built is expected to have a `Dockerfile` at
-the root of the repository.
+In this example, the Git repo being built is expected to have a `Dockerfile` below
+`myfolder` relative root of the repository.

--- a/kaniko/kaniko.yaml
+++ b/kaniko/kaniko.yaml
@@ -9,6 +9,9 @@ spec:
   - name: DOCKERFILE
     description: Path to the Dockerfile to build.
     default: /workspace/Dockerfile
+  - name: CONTEXT
+    description: Build Context
+    default: /workspace
 
   steps:
   - name: build-and-push
@@ -16,6 +19,7 @@ spec:
     args:
     - --dockerfile=${DOCKERFILE}
     - --destination=${IMAGE}
+    - --context=${CONTEXT}
     env:
     - name: DOCKER_CONFIG
       value: /builder/home/.docker


### PR DESCRIPTION
Adding `context` argument for kaniko

I can add in the the [other arguments](https://github.com/GoogleContainerTools/kaniko#additional-flags) as part of this PR if needed.  Unsure how to accomodate repeated values of `--build-arg` though