### PR TITLE
buildkit: update to v0.4.0 (securityContext no longer needed)

### DIFF
--- a/buildkit/0-buildkitd.yaml
+++ b/buildkit/0-buildkitd.yaml
@@ -12,19 +12,33 @@ spec:
     metadata:
       labels:
         app: buildkitd
+      annotations:
+        container.apparmor.security.beta.kubernetes.io/buildkitd: unconfined
+        container.seccomp.security.alpha.kubernetes.io/buildkitd: unconfined
     spec:
       containers:
-# moby/buildkit:v0.3.1-rootless is executed as an unprivileged user and does not support overlayfs on most distros.
-# You can use also use moby/buildkit:v0.3.1
-      - image: moby/buildkit:v0.3.1-rootless@sha256:2407cc7f24e154a7b699979c7ced886805cac67920169dcebcca9166493ee2b6
+# moby/buildkit:vX.Y.Z-rootless is executed as an unprivileged user (UID=1000).
+# If you are using Debian (not Ubuntu) or Arch Linux kernel on each of kubelet nodes,
+# `sudo sh -c "echo 1 > /proc/sys/kernel/unprivileged_userns_clone"` is required.
+#
+# Note that rootless mode does not support OverlayFS snapshotter unless using Ubuntu kernel.
+# However, reflink-based Copy-on-Write can be enabled by mounting XFS volume on /home/user/.local/share/buildkit .
+# The XFS volume needs to be formatted with `mkfs.xfs -m reflink=1`.
+#
+# Also note that rootless mode is known not to work on GCOS kernel: https://github.com/moby/buildkit/issues/879
+#
+# You can also use rootful moby/buildkit:vX.Y.Z instead.
+      - image: moby/buildkit:v0.4.0-rootless@sha256:3877d091e65429f59919ed5591aaeb863b1889a5314bdfdba5ff9c0dfb2f3ed0
         args:
         - --addr
         - tcp://0.0.0.0:1234
+# Disable PID namespace isolation across BuildKit daemon and build containers.
+# To enable PID namespace isolation, you need to remove --oci-worker-no-process-sandbox and
+# set securityContext.procMount to "Unmasked" (or set securityContext.privileged to true).
+        - --oci-worker-no-process-sandbox
         name: buildkitd
         ports:
         - containerPort: 1234
-        securityContext:
-          privileged: true
 ---
 apiVersion: v1
 kind: Service

--- a/buildkit/1-buildtemplate.yaml
+++ b/buildkit/1-buildtemplate.yaml
@@ -17,7 +17,7 @@ spec:
     default: "/workspace"
   - name: BUILDKIT_CLIENT_IMAGE
     description: The name of the BuildKit client (buildctl) image
-    default: "moby/buildkit:v0.3.1-rootless@sha256:2407cc7f24e154a7b699979c7ced886805cac67920169dcebcca9166493ee2b6"
+    default: "moby/buildkit:v0.4.0-rootless@sha256:3877d091e65429f59919ed5591aaeb863b1889a5314bdfdba5ff9c0dfb2f3ed0"
   - name: BUILDKIT_DAEMON_ADDRESS
     description: The address of the BuildKit daemon (buildkitd) service
     default: "tcp://buildkitd:1234"
@@ -28,6 +28,11 @@ spec:
     command: ["buildctl", "--addr=${BUILDKIT_DAEMON_ADDRESS}", "build",
               "--progress=plain",
               "--frontend=dockerfile.v0",
-              "--frontend-opt", "filename=${DOCKERFILE}",
+              "--opt", "filename=${DOCKERFILE}",
               "--local", "context=.", "--local", "dockerfile=.",
-              "--exporter=image", "--exporter-opt", "name=${IMAGE}", "--exporter-opt", "push=${PUSH}"]
+              "--output", "type=image,name=${IMAGE},push=${PUSH}"]
+#
+# To enable distributed cache, add
+#   --export-cache type=inline --import-cache type=registry,ref=${IMAGE}
+# or
+#   --export-cache type=local,dest=/your/nfs/volume --import-cache type=local,src=/your/nfs/volume

--- a/buildkit/README.md
+++ b/buildkit/README.md
@@ -12,7 +12,7 @@ Rootless mode is used by default.
   `./Dockerfile`)
 * **PUSH**: Whether to push or not (_default:_`true`)
 * **DIRECTORY**: Workspace directory (_default:_`/workspace`)
-* **BUILDKIT_CLIENT_IMAGE**: BuildKit client image (_default:_`moby/buildkit:v0.3.1-rootless@sha256:2407cc7f24e154a7b699979c7ced886805cac67920169dcebcca9166493ee2b6`)
+* **BUILDKIT_CLIENT_IMAGE**: BuildKit client image (_default:_`moby/buildkit:vX.Y.Z-rootless@sha256:...`)
 * **BUILDKIT_DAEMON_ADDRESS**: BuildKit daemon address  (_default:_`tcp://buildkitd:1234`)
 
 ## Set up
@@ -25,24 +25,18 @@ First, you need to deploy BuildKit daemon as follows:
 $ kubectl apply -f 0-buildkitd.yaml
 ```
 
-The default image is set to `moby/buildkit:v0.3.1-rootless@sha256:2407cc7f24e154a7b699979c7ced886805cac67920169dcebcca9166493ee2b6`, but you can also build the image manually as follows:
+The default image is set to `moby/buildkit:vX.Y.Z-rootless@sha256:...` (see YAML files for the actual revision), but you can also build the image manually as follows:
 
 ```console
 $ git clone https://github.com/moby/buildkit.git
 $ cd buildkit
-$ git checkout v0.3.1
-$ git rev-parse HEAD
-867bcd343f06228862a33643ae16e55c6a1e5fdb
 $ DOCKER_BUILDKIT=1 docker build --target rootless -f hack/dockerfiles/test.buildkit.Dockerfile .
 ```
 
-Although the BuildKit daemon runs as an unprivileged user (UID=1000), on Kubernetes prior to v1.12, you need to set `securityContext.privileged` to `true` in order to allow runc in the container to mount `/proc`. See [@jessfraz's blog](https://blog.jessfraz.com/post/building-container-images-securely-on-kubernetes/) for further information.
-On Kubernetes v1.12 and later, you may use [`securityContext.procMount`](https://github.com/kubernetes/kubernetes/commit/39004e852bb523d0497343705ee2bf42b4e9c3e3) instead of `securityContext.privileged`.
-To use `securityContext.procMount`, either Docker v18.06, containerd v1.2, or CRI-O v1.12 is also required as the CRI runtime.
-
 If you are using Debian (not Ubuntu) or Arch Linux kernel on each of kubelet nodes, `sudo sh -c "echo 1 > /proc/sys/kernel/unprivileged_userns_clone"` is required.
+See the content of [`0-buildkitd.yaml`](./0-buildkitd.yaml) for further information about rootless mode.
 
-You can also use "rootful" BuildKit image (`moby/buildkit:v0.3.1`) at your own risk.
+You can also use "rootful" BuildKit image (`moby/buildkit:vX.Y.Z`) at your own risk.
 
 ### Step 1: Register BuildKit build template
 

--- a/buildkit/README.md
+++ b/buildkit/README.md
@@ -22,15 +22,15 @@ Rootless mode is used by default.
 First, you need to deploy BuildKit daemon as follows:
 
 ```console
-$ kubectl apply -f 0-buildkitd.yaml
+kubectl apply -f 0-buildkitd.yaml
 ```
 
 The default image is set to `moby/buildkit:vX.Y.Z-rootless@sha256:...` (see YAML files for the actual revision), but you can also build the image manually as follows:
 
 ```console
-$ git clone https://github.com/moby/buildkit.git
-$ cd buildkit
-$ DOCKER_BUILDKIT=1 docker build --target rootless -f hack/dockerfiles/test.buildkit.Dockerfile .
+git clone https://github.com/moby/buildkit.git
+cd buildkit
+DOCKER_BUILDKIT=1 docker build --target rootless -f hack/dockerfiles/test.buildkit.Dockerfile .
 ```
 
 If you are using Debian (not Ubuntu) or Arch Linux kernel on each of kubelet nodes, `sudo sh -c "echo 1 > /proc/sys/kernel/unprivileged_userns_clone"` is required.
@@ -41,7 +41,7 @@ You can also use "rootful" BuildKit image (`moby/buildkit:vX.Y.Z`) at your own r
 ### Step 1: Register BuildKit build template
 
 ```console
-$ kubectl apply -f 1-buildtemplate.yaml
+kubectl apply -f 1-buildtemplate.yaml
 ```
 
 ## Usage


### PR DESCRIPTION
Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>