### PR TITLE
Correct error BuildTemplate md link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Knative Build Templates
 
 This repository contains a library of
-`BuildTemplate` [resources](https://github.com/knative/docs/blob/master/build/build-templates.md) which are designed to be reusable by many applications.
+`BuildTemplate` [resources](https://github.com/knative/docs/blob/master/docs/build/build-templates.md) which are designed to be reusable by many applications.
 
 Each build template is in a separate directory along with a README.md and a Kubernetes manifest, so you can choose which build templates to install on your cluster.
 


### PR DESCRIPTION
The original link doesn't exist and report 404 page not found. I corrected the page link to the right url.

Signed-off-by: zhangtbj <zhangtbj@cn.ibm.com>